### PR TITLE
mambaforge: Update to version 22.11.1-4

### DIFF
--- a/bucket/mambaforge.json
+++ b/bucket/mambaforge.json
@@ -1,5 +1,5 @@
 {
-    "version": "22.11.1-2",
+    "version": "22.11.1-4",
     "description": "A conda-forge distribution",
     "homepage": "https://github.com/conda-forge/miniforge",
     "license": "BSD-3-Clause",
@@ -9,8 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/conda-forge/miniforge/releases/download/22.11.1-2/Mambaforge-22.11.1-2-Windows-x86_64.exe",
-            "hash": "3dfdaf08d86acdbf9c0b1f390719a0c671483dd327f3f594355504d7bce18402"
+            "url": "https://github.com/conda-forge/miniforge/releases/download/22.11.1-4/Mambaforge-22.11.1-4-Windows-x86_64.exe",
+            "hash": "ff9cc38611211814c5d18e388fb33a421017f2adab1f68cfbdaa42afe858a64a"
         }
     },
     "installer": {


### PR DESCRIPTION
just in case you're not familiar with running `checkver.ps1` to update to the latest release!